### PR TITLE
extras: pkg-config.in: Fix consecutive -I|-L flags are not replaced

### DIFF
--- a/extras/pkg-config.in
+++ b/extras/pkg-config.in
@@ -24,14 +24,18 @@ for dir in $PATH; do
 
   IFS="$oldIFS"
 
-  out=$("$prog" --define-prefix "$@");
+  out=$(PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 \
+        PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 \
+        "$prog" --define-prefix "$@");
   rc=$?
 
   printf '%s\n' "$out" | sed -E \
-    -e "s,(^|[[:blank:]])-I[[:blank:]]*(@PREFIX@/@TARGETSPEC@|/@unixroot)?/usr(/local)?/include([[:blank:]]|$), ,g" \
-    -e "s,(^|[[:blank:]])-L[[:blank:]]*(/@unixroot)?/usr(/local)?/lib([[:blank:]]|$), ,g" \
-    -e "s,(^|[[:blank:]])-L[[:blank:]]*@PREFIX@/@TARGETSPEC@/usr/lib([[:blank:]]|$), ,g" \
-    -e "s,(^|[[:blank:]])(-I|-L)[[:blank:]]*(/@unixroot|(/usr))([[:blank:]/]|$), \2@PREFIX@/@TARGETSPEC@\4\5,g"
+    -e ":loop" \
+    -e "s,(^|[[:blank:]])-I[[:blank:]]*(@PREFIX@/@TARGETSPEC@|/@unixroot)?(/usr(/local)?)?/include([[:blank:]]|$), ," \
+    -e "s,(^|[[:blank:]])-L[[:blank:]]*(/@unixroot)?(/usr(/local)?)?/lib([[:blank:]]|$), ," \
+    -e "s,(^|[[:blank:]])-L[[:blank:]]*@PREFIX@/@TARGETSPEC@(/usr)?/lib([[:blank:]]|$), ," \
+    -e "s,(^|[[:blank:]])(-I|-L)[[:blank:]]*(/@unixroot|(/usr))([[:blank:]/]|$), \2@PREFIX@/@TARGETSPEC@\4\5," \
+    -e "t loop"
 
   exit $rc
 done


### PR DESCRIPTION
And
1. replace all -I and -L flags including system flags
2. consider /include|/lib without /usr|/usr/local cases