### PR TITLE
extras: setemxenv.in: Use PKG_CONFIG_LIBDIR instead of PKG_CONFIG_PATH

### DIFF
--- a/extras/setemxenv.in
+++ b/extras/setemxenv.in
@@ -3,6 +3,6 @@
 if ! which emximp > /dev/null 2>&1; then
   export PATH="@PREFIX@/bin${PATH:+:}$PATH"
   export GCCOPT="$GCCOPT -idirafter @PREFIX@/@TARGETSPEC@/include/os2tk45"
-  export PKG_CONFIG_PATH="@PREFIX@/@TARGETSPEC@/lib/pkgconfig:@PREFIX@/lib/pkgconfig${PKG_CONFIG_PATH:+:}$PKG_CONFIG_PATH"
+  export PKG_CONFIG_LIBDIR="@PREFIX@/@TARGETSPEC@/lib/pkgconfig:@PREFIX@/lib/pkgconfig${PKG_CONFIG_LIBDIR:+:}$PKG_CONFIG_LIBDIR"
   export ACLOCAL_PATH="@PREFIX@/@TARGETSPEC@/share/aclocal:@PREFIX@/share/aclocal${ACLOCAL_PATH:+:}$ACLOCAL_PATH"
 fi


### PR DESCRIPTION
PKG_CONFIG_LIBDIR overrides the default search paths, but PKG_CONFIG_PATH appends the given paths to the default search paths.