### PR TITLE
extras: install[rpm]zip: Ignore pthread using date-based version style

### DIFF
--- a/extras/installrpm
+++ b/extras/installrpm
@@ -156,7 +156,8 @@ $MKDIR_P "$rpmdir"
 
 echo "Downloading the RPM file list..."
 $CURL "$rpmarchurl/" "$rpmnoarchurl/" \
-  | $SED -n -e "s/^.*href=\"\(.*\.rpm\)\".*$/\1@@@rel@@@/p" > "$rpmlst.tmp"
+  | $SED -n -e "s/^.*href=\"\(.*\.rpm\)\".*$/\1@@@rel@@@/" \
+            -e "/^pthread.*-20[0-9]*-[0-9][0-9]*[-_.].*$/!p" > "$rpmlst.tmp"
 
 if $opt_e; then
   $CURL "$rpmexparchurl/" "$rpmexpnoarchurl/" \

--- a/extras/installrpmzip
+++ b/extras/installrpmzip
@@ -74,7 +74,8 @@ $MKDIR_P "$zipdir"
 
 echo "Downloading the ZIP file list..."
 $CURL "$zipurl/" \
-  | $SED -n -e "s/^.*href=\"\(.*\.zip\)\".*$/\1@@@rel@@@/p" > "$ziplst.tmp"
+  | $SED -n -e "s/^.*href=\"\(.*\.zip\)\".*$/\1@@@rel@@@/" \
+            -e "/^pthread.*-20[0-9]*-[0-9][0-9]*[-_.].*$/!p" > "$ziplst.tmp"
 
 if $opt_e; then
   $CURL "$zipexpurl/" \


### PR DESCRIPTION
They are old and obsolete versions, and confuse sorting by versions.